### PR TITLE
CORE: [PARQUET] Log corrupted parquet filenames to trace bad nodes that may have written them.

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -135,6 +135,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
         } else {
           this.last = model.read(null);
         }
+
         valuesRead += 1;
 
         return last;
@@ -144,6 +145,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
           // that produced the corrupt file, parquet lib doesn't do this today.
           LOG.error("Error decoding Parquet file {}", reader.getFile(), e);
         }
+
         throw e;
       }
     }


### PR DESCRIPTION
We should intercept the `ParquetDecodingException` and log the corrupted parquet file to make this easily discoverable. Knowing the exact parquet file that the executor failed on is essential for identifying bad nodes in a cluster that could be producing corrupt data, and eventually take them out.
```
23/12/10 13:28:04 WARN task-result-getter-0 TaskSetManager: Lost task 55.0 in stage 0.0 (TID 55) (ip-100-74-15-132.ec2.internal executor 28): org.apache.iceberg.bdp.shaded.org.apache.parquet.io.ParquetDecodingException: could not decompress page
```


